### PR TITLE
Add CORS header

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,10 @@ export default {
     ) {
       return new Response(
         JSON.stringify({ names: { [name]: nip19.decode(name).data } }),
-        { headers: { "cache-control": "public, max-age=31536000, immutable" } }
+        { headers: {
+          "cache-control": "public, max-age=31536000, immutable",
+          'Access-Control-Allow-Origin': '*',
+        } }
       );
     }
     if (pathname === "/") {


### PR DESCRIPTION
Add `Access-Control-Allow-Origin` header to allow access from javascript apps.

ref: https://github.com/nostr-protocol/nips/blob/master/05.md#allowing-access-from-javascript-apps

> JavaScript Nostr apps may be restricted by browser [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policies that prevent them from accessing /.well-known/nostr.json on the user's domain. When CORS prevents JS from loading a resource, the JS program sees it as a network failure identical to the resource not existing, so it is not possible for a pure-JS app to tell the user for certain that the failure was caused by a CORS issue. JS Nostr apps that see network failures requesting /.well-known/nostr.json files may want to recommend to users that they check the CORS policy of their servers, e.g.:

> $ curl -sI https://example.com/.well-known/nostr.json?name=bob | grep -i ^Access-Control
Access-Control-Allow-Origin: *
Users should ensure that their /.well-known/nostr.json is served with the HTTP header Access-Control-Allow-Origin: * to ensure it can be validated by pure JS apps running in modern browsers.